### PR TITLE
ICO support for GD driver

### DIFF
--- a/Classes/Utility/GeneralHelper.php
+++ b/Classes/Utility/GeneralHelper.php
@@ -6,6 +6,7 @@ namespace KonradMichalik\Typo3EnvironmentIndicator\Utility;
 
 use KonradMichalik\Typo3EnvironmentIndicator\Configuration;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class GeneralHelper
 {
@@ -15,7 +16,7 @@ class GeneralHelper
 
         $path = Environment::getPublicPath() . '/' . $defaultPath;
         if (!file_exists($path)) {
-            mkdir($path, 0777, true);
+            GeneralUtility::mkdir_deep($path);
         }
 
         if (!$publicPath) {

--- a/Documentation/Configuration/Favicon.rst
+++ b/Documentation/Configuration/Favicon.rst
@@ -301,6 +301,9 @@ ColorizeModifier
 
 Overlay an additional image to the original favicon regarding the application context.
 
+..  warning::
+    This modifier is only available with "Imagick" image driver.
+
 ..  code-block:: php
     :caption: ext_localconf.php
 

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -13,9 +13,7 @@ Requirements
 
 -   PHP 8.1 - 8.4
 -   TYPO3 11.5 LTS - 13.4 LTS
--   ImageMagick
-
-    -    Required for the `.ico` favicon file modification
+-   ImageDriver: GD, Imagick or libvips
 
 ..  _steps:
 
@@ -34,7 +32,7 @@ Or download it from the
 Configuration
 ============
 
-Include the static TypoScript template "Environment Indicator" or directly import it in your sitepackage:
+Include the static TypoScript template "Environment Indicator" or directly import it in your sitepackage (only necessary for the :ref:`frontend Hint <frontend-hint>`):
 
 
 ..  code-block:: typoscript

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
 	],
 	"require": {
 		"php": "^8.1",
-		"ext-imagick": "*",
 		"intervention/image": "^3.0",
+		"lordelph/icofileloader": "^3.0.0",
 		"typo3/cms-core": "^11.5 || ^12.4 || ^13.4"
 	},
 	"require-dev": {


### PR DESCRIPTION
Add ICO to PNG conversion for GD image driver in FaviconHandler using the composer package [lordelph/icofileloader](https://github.com/lordelph/icofileloader).