### PR TITLE
fix: undefined array key

### DIFF
--- a/Classes/Backend/ToolbarItems/ProjectStatusItem.php
+++ b/Classes/Backend/ToolbarItems/ProjectStatusItem.php
@@ -87,8 +87,7 @@ class ProjectStatusItem implements ToolbarItemInterface
     {
         return array_merge(
             GeneralHelper::getGlobalConfiguration()['backendToolbar'],
-            array_key_exists('backendToolbar', $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['context'][Environment::getContext()->__toString()]) ?
-                $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['context'][Environment::getContext()->__toString()]['backendToolbar'] : []
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['context'][Environment::getContext()->__toString()]['backendToolbar'] ?? []
         );
     }
 }


### PR DESCRIPTION
When having an undefined application context (like `Development/Local`), the config merge crashes. This PR fixes this issue and simplifies the array access.