### PR TITLE
fix: set fallback color

### DIFF
--- a/Classes/Backend/ToolbarItems/ProjectStatusItem.php
+++ b/Classes/Backend/ToolbarItems/ProjectStatusItem.php
@@ -58,7 +58,7 @@ class ProjectStatusItem implements ToolbarItemInterface
                 'icon' => $this->getBackendToolbarConfiguration()['icon']['context'] ?? 'information-application-context',
                 'name' => $this->getBackendToolbarConfiguration()['name'] ?? Environment::getContext()->__toString(),
                 'color' => $this->getBackendToolbarConfiguration()['color'] ?? 'transparent',
-                'textColor' => ColorUtility::getOptimalTextColor($this->getBackendToolbarConfiguration()['color']),
+                'textColor' => ColorUtility::getOptimalTextColor($this->getBackendToolbarConfiguration()['color'] ?? 'transparent'),
             ],
         ])->render();
     }


### PR DESCRIPTION
This PR prevents an undefined array key error in case no `color` value is set for the backend toolbar