### PR TITLE
fix: add early return for empty triggers and indicators in configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -37,3 +37,11 @@ insert_final_newline = unset
 trim_trailing_whitespace = unset
 indent_style = unset
 indent_size = unset
+
+[/Documentation/**]
+charset = unset
+end_of_line = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset
+indent_style = unset
+indent_size = unset

--- a/Classes/Configuration/Handler.php
+++ b/Classes/Configuration/Handler.php
@@ -30,6 +30,11 @@ class Handler
             $configuration['indicators'][] = $indicator;
         }
 
+        if ((empty($configuration['triggers']) && empty($configuration['indicators'])) ||
+            !isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['configuration'])
+        ) {
+            return;
+        }
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['configuration'][] = $configuration;
     }
 


### PR DESCRIPTION
Fixes #14 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by preventing empty or uninitialized configurations from being added.
- **Chores**
  - Disabled automatic formatting rules for documentation files to preserve their original style.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->