### PR TITLE
fix: improve description for extension version in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
     id: extension-version
     attributes:
       label: Extension version
-      description: What version of EXT:solver are you using?
+      description: What version of the extension are you using?
       placeholder: 'e.g. 0.1.0'
     validations:
       required: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Improved the bug report template by clarifying the prompt for reporting the extension version, changing it to “What version of the extension are you using?” for clearer guidance and consistency when submitting issues.
- Chores
  - Updated issue template text to enhance reporting quality and reduce ambiguity for users filing bug reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->