### PR TITLE
fix: update PHP version constraints in composer.json and composer.lock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		}
 	],
 	"require": {
-		"php": "^8.1",
+		"php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
 		"ext-filter": "*",
 		"intervention/image": "^3.7",
 		"lordelph/icofileloader": "^3.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "769561cd2573be9311fea0f19bb48aa5",
+    "content-hash": "837fee1ec9e01df04314cd55609f9fb2",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -13376,7 +13376,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-filter": "*"
     },
     "platform-dev": {},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated PHP runtime compatibility to support 8.1.x–8.4.x, improving installation across newer environments.
  - No functional changes to features or workflows; existing setups on supported versions continue to work as before.
  - Upgrade is seamless for users on supported PHP versions, helping maintain compatibility with modern releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->