### PR TITLE
docs: add security policy guidelines to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+If you believe you have found a vulnerability in this project, please follow the guidelines below.
+
+> [!CAUTION]
+> Please do not create GitHub issues for security vulnerabilities!
+
+## Reporting a Vulnerability
+
+Please contact [hej@konradmichalik.dev](mailto:hej@konradmichalik.dev) instead.
+Your report should include the following information:
+
+- The exact version or version range you analyzed.
+- The TYPO3 version used during your analysis.
+- A step-by-step description of how to exploit the potential vulnerability.
+
+> [!TIP]
+> If you suspect a critical vulnerability, you may also contact the _TYPO3 Security Team_. For further details, please
+> refer to  [TYPO3's Security Policy](https://github.com/TYPO3/typo3/blob/main/SECURITY.md).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a security policy outlining how to report vulnerabilities.
  * Instructs not to open public issues for security reports; provides a dedicated contact channel.
  * Specifies required details (affected versions, TYPO3 version, step-by-step exploit).
  * Advises contacting the TYPO3 Security Team for critical issues.
  * Includes a reference to the official TYPO3 Security Policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->