### PR TITLE
refactor: remove 'Both' case from Scope enum

### DIFF
--- a/Classes/Enum/Scope.php
+++ b/Classes/Enum/Scope.php
@@ -21,7 +21,6 @@ namespace KonradMichalik\Typo3EnvironmentIndicator\Enum;
  */
 enum Scope: string
 {
-    case Both = 'both';
     case Frontend = 'frontend';
     case Backend = 'backend';
     case Global = 'global';

--- a/Tests/Unit/Enum/ScopeTest.php
+++ b/Tests/Unit/Enum/ScopeTest.php
@@ -28,16 +28,14 @@ class ScopeTest extends TestCase
     {
         $scopes = Scope::cases();
 
-        self::assertCount(4, $scopes);
-        self::assertEquals(Scope::Both, $scopes[0]);
-        self::assertEquals(Scope::Frontend, $scopes[1]);
-        self::assertEquals(Scope::Backend, $scopes[2]);
-        self::assertEquals(Scope::Global, $scopes[3]);
+        self::assertCount(3, $scopes);
+        self::assertEquals(Scope::Frontend, $scopes[0]);
+        self::assertEquals(Scope::Backend, $scopes[1]);
+        self::assertEquals(Scope::Global, $scopes[2]);
     }
 
     public function testScopeNames(): void
     {
-        self::assertEquals('Both', Scope::Both->name);
         self::assertEquals('Frontend', Scope::Frontend->name);
         self::assertEquals('Backend', Scope::Backend->name);
         self::assertEquals('Global', Scope::Global->name);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified scope configuration by removing the "Both" option. Environment indicator now supports Frontend, Backend, and Global scopes exclusively.

* **Tests**
  * Updated test cases to reflect changes in available scope options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->