### PR TITLE
fix: add missing fallbacks for optional configuration array keys

### DIFF
--- a/Classes/Backend/ToolbarItems/ContextItem.php
+++ b/Classes/Backend/ToolbarItems/ContextItem.php
@@ -93,7 +93,7 @@ class ContextItem implements ToolbarItemInterface
     {
         $toolbarConfig = $this->getBackendToolbarConfiguration();
 
-        return [] !== $toolbarConfig ? $toolbarConfig['index'] : 0;
+        return $toolbarConfig['index'] ?? 0;
     }
 
     /**

--- a/Classes/Utility/GeneralHelper.php
+++ b/Classes/Utility/GeneralHelper.php
@@ -33,7 +33,7 @@ class GeneralHelper
 {
     public static function getFolder(IndicatorInterface $indicator, bool $publicPath = true): string
     {
-        $defaultPath = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['defaults'][$indicator::class]['_path'];
+        $defaultPath = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['defaults'][$indicator::class]['_path'] ?? '';
 
         $path = Environment::getPublicPath().'/'.$defaultPath;
         if (!file_exists($path)) {

--- a/Classes/ViewHelpers/FaviconViewHelper.php
+++ b/Classes/ViewHelpers/FaviconViewHelper.php
@@ -55,6 +55,7 @@ class FaviconViewHelper extends AbstractViewHelper
 
         $extensionConfig = $this->extensionConfiguration->get(Configuration::EXT_KEY);
         if (($extensionConfig[$applicationType->value]['favicon'] ?? false) !== true
+            || !isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['context'])
             || !array_key_exists(Environment::getContext()->__toString(), $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['context'])
             || !array_key_exists('favicon', $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['context'][Environment::getContext()->__toString()])
         ) {


### PR DESCRIPTION
## Summary

- Fix TypeError when optional configuration keys (e.g. `index`) are omitted in `ext_localconf.php` with `defaultConfiguration` disabled
- Add null coalescing fallback for `_path` access in `GeneralHelper::getFolder()`
- Add `isset()` guard for `context` key in `FaviconViewHelper`

Closes #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to prevent notices when configuration values are missing
  * Enhanced favicon display with better fallback handling when extension context is unavailable
  * Strengthened path resolution to gracefully handle undefined settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->