### PR TITLE
fix: add missing fallbacks for optional modifier configuration keys

### DIFF
--- a/Classes/Image/Modifier/ColorizeModifier.php
+++ b/Classes/Image/Modifier/ColorizeModifier.php
@@ -37,7 +37,7 @@ class ColorizeModifier extends AbstractModifier implements ModifierInterface
         }
 
         $targetColorArray = ColorUtility::colorToRgb($this->configuration['color']);
-        $opacityPercentage = ($this->configuration['opacity'] * 100).'%';
+        $opacityPercentage = (($this->configuration['opacity'] ?? 1) * 100).'%';
         $targetColor = sprintf('rgb(%d, %d, %d)', $targetColorArray[0], $targetColorArray[1], $targetColorArray[2]);
 
         $imagick = $image->core()->native();

--- a/Classes/Image/Modifier/TextModifier.php
+++ b/Classes/Image/Modifier/TextModifier.php
@@ -46,7 +46,7 @@ class TextModifier extends AbstractModifier implements ModifierInterface
 
         $configuration = $this->configuration;
         $text = $configuration['text'];
-        $fontPath = GeneralUtility::getFileAbsFileName($configuration['font']);
+        $fontPath = isset($configuration['font']) ? GeneralUtility::getFileAbsFileName($configuration['font']) : '';
         $position = $configuration['position'] ?? 'bottom';
         $fontSize = self::INITIAL_FONT_SIZE;
 
@@ -61,7 +61,9 @@ class TextModifier extends AbstractModifier implements ModifierInterface
         $yPosition = ('top' === $position) ? $padding : $image->height() - $padding;
 
         $image->text($wrappedText, (int) ($image->width() / 2), $yPosition, static function (FontFactory $font) use ($fontSize, $configuration, $fontPath, $position): void {
-            $font->filename($fontPath);
+            if ('' !== $fontPath) {
+                $font->filename($fontPath);
+            }
             $font->size($fontSize);
             $font->color($configuration['color']);
             if (isset($configuration['stroke']['color'])) {

--- a/Classes/Image/Modifier/TriangleModifier.php
+++ b/Classes/Image/Modifier/TriangleModifier.php
@@ -32,7 +32,7 @@ class TriangleModifier extends AbstractModifier implements ModifierInterface
         $width = $image->width();
         $height = $image->height();
 
-        $triangleSize = (int) ($width * $this->configuration['size']);
+        $triangleSize = (int) ($width * ($this->configuration['size'] ?? 0.7));
         $position = $this->configuration['position'] ?? 'bottom right';
 
         $points = match ($position) {


### PR DESCRIPTION
## Summary

- Add fallbacks for optional configuration keys in image modifiers that caused TypeErrors when keys were omitted with `defaultConfiguration` disabled

## Changes

- `Classes/Image/Modifier/TextModifier.php` - Add `isset()` guard for optional `font` key and conditional `$font->filename()` call
- `Classes/Image/Modifier/ColorizeModifier.php` - Add `?? 1` fallback for optional `opacity` key
- `Classes/Image/Modifier/TriangleModifier.php` - Add `?? 0.7` fallback for optional `size` key

Follow-up to #79 — reported by @richardkrikler in #75 (comment).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling by adding safe default values for optional configuration settings.
  * Image opacity now applies a neutral default when unconfigured.
  * Font processing gracefully skips when font configuration is absent.
  * Triangle sizing now defaults to 70% of image width if unspecified in configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->