### PR TITLE
fix: register ThemeInfoField as FormEngine renderType for TYPO3 v14.2+

### DIFF
--- a/Classes/Backend/Form/Element/ThemeInfoElement.php
+++ b/Classes/Backend/Form/Element/ThemeInfoElement.php
@@ -40,7 +40,7 @@ class ThemeInfoElement extends AbstractFormElement
             'LLL:EXT:typo3_environment_indicator/Resources/Private/Language/locallang.xlf:userSettings.themeInfo',
         );
 
-        $html = '<div class="alert alert-info" role="alert">'
+        $html = '<div class="alert alert-info">'
             .'<div class="alert-body">'
             .htmlspecialchars($message, \ENT_QUOTES)
             .'</div>'

--- a/Classes/Backend/Form/Element/ThemeInfoElement.php
+++ b/Classes/Backend/Form/Element/ThemeInfoElement.php
@@ -11,40 +11,44 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace KonradMichalik\Typo3EnvironmentIndicator\Backend\UserSettings;
+namespace KonradMichalik\Typo3EnvironmentIndicator\Backend\Form\Element;
 
 use KonradMichalik\Typo3EnvironmentIndicator\Configuration\Indicator\Backend\Theme;
 use KonradMichalik\Typo3EnvironmentIndicator\Utility\GeneralHelper;
-use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Backend\Form\Element\AbstractFormElement;
 
 /**
- * ThemeInfoField.
+ * ThemeInfoElement.
  *
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
-class ThemeInfoField
+class ThemeInfoElement extends AbstractFormElement
 {
     /**
-     * Renders an info box in User Settings when the Theme indicator is active.
-     *
-     * @param array<string, mixed> $config
+     * @return array<string, mixed>
      */
-    public function render(array &$config, object $parentObject): string
+    public function render(): array
     {
+        $resultArray = $this->initializeResultArray();
+
         if (!$this->isApplicable()) {
-            return '';
+            return $resultArray;
         }
 
         $message = $this->getLanguageService()->sL(
             'LLL:EXT:typo3_environment_indicator/Resources/Private/Language/locallang.xlf:userSettings.themeInfo',
         );
 
-        return '<div class="alert alert-info" role="alert">'
+        $html = '<div class="alert alert-info" role="alert">'
             .'<div class="alert-body">'
             .htmlspecialchars($message, \ENT_QUOTES)
             .'</div>'
             .'</div>';
+
+        $resultArray['html'] = $this->wrapWithFieldsetAndLegend($html);
+
+        return $resultArray;
     }
 
     private function isApplicable(): bool
@@ -52,10 +56,5 @@ class ThemeInfoField
         return GeneralHelper::isMinimumTypo3Version(14)
             && GeneralHelper::isExtensionFeatureEnabled('backend/theme')
             && GeneralHelper::isCurrentIndicator(Theme::class);
-    }
-
-    private function getLanguageService(): LanguageService
-    {
-        return $GLOBALS['LANG'];
     }
 }

--- a/Configuration/TCA/Overrides/be_users.php
+++ b/Configuration/TCA/Overrides/be_users.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-use KonradMichalik\Typo3EnvironmentIndicator\Backend\UserSettings\ThemeInfoField;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 defined('TYPO3') || exit;
@@ -24,7 +23,7 @@ if (method_exists(ExtensionManagementUtility::class, 'addUserSetting')) {
             'label' => '',
             'config' => [
                 'type' => 'user',
-                'userFunc' => ThemeInfoField::class.'->render',
+                'renderType' => 'environmentIndicatorThemeInfo',
             ],
         ],
         'after:theme',

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -18,6 +18,12 @@ defined('TYPO3') || exit;
 
 Configuration::addToolbarItems();
 
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1744624800] = [
+    'nodeName' => 'environmentIndicatorThemeInfo',
+    'priority' => 40,
+    'class' => KonradMichalik\Typo3EnvironmentIndicator\Backend\Form\Element\ThemeInfoElement::class,
+];
+
 // Default configuration
 $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['current'] = [];
 $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['defaults'] = [

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-use KonradMichalik\Typo3EnvironmentIndicator\Backend\UserSettings\ThemeInfoField;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\{ExtensionManagementUtility, GeneralUtility};
 
@@ -23,7 +22,7 @@ if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() >= 14
 ) {
     $GLOBALS['TYPO3_USER_SETTINGS']['columns']['environmentIndicatorThemeInfo'] = [
         'type' => 'user',
-        'userFunc' => ThemeInfoField::class.'->render',
+        'renderType' => 'environmentIndicatorThemeInfo',
         'label' => '',
     ];
 


### PR DESCRIPTION
## Summary

- Fix dummy output warning in User Settings for `environmentIndicatorThemeInfo` field
- TYPO3 v14.2 migrated User Settings to TCA — `type="user"` now requires a `renderType` instead of `userFunc`

## Changes

- `Classes/Backend/Form/Element/ThemeInfoElement.php` — New FormEngine element extending `AbstractFormElement`, replaces old `userFunc`-based rendering
- `ext_localconf.php` — Register `environmentIndicatorThemeInfo` renderType via `nodeRegistry`
- `Configuration/TCA/Overrides/be_users.php` — Use `renderType` instead of `userFunc` in `addUserSetting()` config
- `ext_tables.php` — Update fallback path (v14.0–14.1) to also use `renderType`
- `Classes/Backend/UserSettings/ThemeInfoField.php` — Removed (no longer referenced)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized the theme selection form element to use the latest form rendering system, improving code maintainability and compatibility with current framework standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->