### PR TITLE
fix: upgrade dotenv-connector constraint for Composer 2 compatibility

### DIFF
--- a/Tests/Acceptance/Fixtures/packages/sitepackage/composer.json
+++ b/Tests/Acceptance/Fixtures/packages/sitepackage/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 	  "konradmichalik/typo3-environment-indicator": "*",
-	  "helhum/dotenv-connector": "1.1.0"
+	  "helhum/dotenv-connector": "^3.0"
 	},
 	"suggest": {},
 	"conflict": {},


### PR DESCRIPTION
## Summary

- `helhum/dotenv-connector` was pinned to `1.1.0` which only supports Composer 1 (`composer-plugin-api ^1.0`)
- Updated constraint to `^3.0` to resolve installation failures with Composer 2

## Changes

- `Tests/Acceptance/Fixtures/packages/sitepackage/composer.json` — Update `helhum/dotenv-connector` from `1.1.0` to `^3.0`