### PR TITLE
chore: update DDEV docroot and PHP version

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 name: typo3-environment-indicator
 type: php
-docroot: .test
-php_version: "8.3"
+docroot: .Build
+php_version: "8.2"
 webserver_type: apache-fpm
 router_http_port: "80"
 router_https_port: "443"


### PR DESCRIPTION
## Summary

- Change DDEV docroot from `.test` to `.Build`
- Change PHP version from 8.3 to 8.2

## Changes

- `.ddev/config.yaml` - Update docroot and PHP version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration: switched to PHP version 8.2 and adjusted the web root directory for the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->