### PR TITLE
chore(ci): remove php constraint from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,5 @@
 	],
 	"ignorePaths": [
 		"Tests/Acceptance/Fixtures/packages/sitepackage/composer.json"
-	],
-	"constraints": {
-		"php": ">=8.2"
-	}
+	]
 }


### PR DESCRIPTION
## Summary

- Remove redundant `constraints.php` field from Renovate configuration

## Changes

- `renovate.json` - Drop `constraints.php` block; PHP constraints are already defined in `composer.json` and inherited by Renovate