### PR TITLE
fix: replace deprecated f:asset useNonce with CSP nonce attribute

### DIFF
--- a/Resources/Private/Templates/TechnicalContextHint.html
+++ b/Resources/Private/Templates/TechnicalContextHint.html
@@ -1,8 +1,8 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-<f:asset.css identifier="technical-context-hint" href="EXT:typo3_environment_indicator/Resources/Public/Css/TechnicalContextHint.css"  useNonce="true"/>
-<f:asset.script identifier="technical-context-hint-js" src="EXT:typo3_environment_indicator/Resources/Public/JavaScript/TechnicalContextHint.js"  useNonce="true"/>
+<f:asset.css identifier="technical-context-hint" href="EXT:typo3_environment_indicator/Resources/Public/Css/TechnicalContextHint.css"  nonce="{f:security.nonce(directive: 'style-src', scope: 'static')}"/>
+<f:asset.script identifier="technical-context-hint-js" src="EXT:typo3_environment_indicator/Resources/Public/JavaScript/TechnicalContextHint.js"  nonce="{f:security.nonce(directive: 'script-src', scope: 'static')}"/>
 
 <div
     class="technical-context technical-context--custom-colors"

--- a/Resources/Private/Templates/ToolbarItems/ContextItem.html
+++ b/Resources/Private/Templates/ToolbarItems/ContextItem.html
@@ -1,7 +1,7 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-    <f:asset.css identifier="project-status" useNonce="true">
+    <f:asset.css identifier="project-status" nonce="{f:security.nonce(directive: 'style-src')}">
         .topbar-header-project-status__context {
             display: inline-block;
             padding: 10.5px 13.5px;


### PR DESCRIPTION
## Summary

- Replace the deprecated `useNonce` argument on `f:asset.css`/`f:asset.script` (deprecated in TYPO3 v14, removed in v15) with a version-compatible `nonce` attribute
- Avoids the v14-only `csp` argument so the extension keeps working on TYPO3 v13.4 (composer constraint is `^13.4 || ^14.3`)
- Uses `f:security.nonce()` which exists in both v13 and v14 and consumes the same request nonce, so the CSP nonce stays identical to the header — styling/JS behavior unchanged

## Changes

- `Resources/Private/Templates/ToolbarItems/ContextItem.html` - inline CSS now uses `nonce="{f:security.nonce(directive: 'style-src')}"`
- `Resources/Private/Templates/TechnicalContextHint.html` - external CSS/JS use `nonce="{f:security.nonce(directive: 'style-src'|'script-src', scope: 'static')}"