### PR TITLE
feat: disable experimental backend theme by default

### DIFF
--- a/Documentation/Indicators/BackendTheme.rst
+++ b/Documentation/Indicators/BackendTheme.rst
@@ -19,6 +19,13 @@ Backend theme
     currently considered internal API. While the overridden CSS custom properties
     are stable within TYPO3 v14, they may change in future major versions.
 
+..  note::
+    Because it is experimental, the backend theme is **disabled by default**.
+    Enable it via the extension configuration setting :code:`backend.theme`
+    (:guilabel:`Admin Tools > Settings > Extension Configuration`). Even with the
+    default configuration active, the backend stays uncolored until this flag is
+    turned on.
+
 ..  figure:: /Images/theme.jpg
     :alt: Backend theme indicator preview
 

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -16,5 +16,5 @@ backend.logo = 1
 backend.context = 1
 # cat=backend/enable/40; type=boolean; label=Enable the backend toolbar item / backend topbar also in production context
 backend.contextProduction = 1
-# cat=backend/enable/50; type=boolean; label=Enable the backend theme modification (TYPO3 v14+ only). Colors the entire backend based on the environment.
-backend.theme = 1
+# cat=backend/enable/50; type=boolean; label=Enable the backend theme modification (TYPO3 v14+ only, experimental). Colors the entire backend based on the environment.
+backend.theme = 0


### PR DESCRIPTION
## Summary

- The experimental backend theme indicator (TYPO3 v14+) was active out of the box, coloring the entire backend whenever the default configuration and a matching application context applied.
- An experimental feature should be opt-in, so its extension configuration flag now defaults to off. All other indicators (favicon, logo, toolbar, hint, widget) are unaffected.

## Behavior

- `backend.theme` now defaults to `0`. The theme indicator stays in the default presets but only takes effect once the flag is enabled in *Admin Tools > Settings > Extension Configuration*, since `ThemeItem::isApplicable()` checks it.
- Existing installations that rely on the theming must enable the flag once after updating.

## Changes

- `ext_conf_template.txt` - Default `backend.theme` to `0` and mark the setting as experimental in its label.
- `Documentation/Indicators/BackendTheme.rst` - Document that the backend theme is disabled by default and how to enable it.