### PR TITLE
feat: add extension title prefix to composer description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "konradmichalik/typo3-environment-indicator",
-	"description": "TYPO3 extension with several features to show an environment indicator in the TYPO3 frontend and backend.",
+	"description": "Environment Indicator - TYPO3 extension with several features to show an environment indicator in the TYPO3 frontend and backend.",
 	"license": [
 		"GPL-2.0-or-later"
 	],


### PR DESCRIPTION
## Summary

- Prepend the extension title `Environment Indicator` to the composer description so it surfaces as the extension title in the TYPO3 Extension Manager (Composer mode)

## Changes

- `composer.json` - Add `Environment Indicator - ` prefix to the `description` field