### PR TITLE
refactor: delegate color handling to php-color package

### DIFF
--- a/Classes/Image/Modifier/ColorizeModifier.php
+++ b/Classes/Image/Modifier/ColorizeModifier.php
@@ -16,7 +16,8 @@ namespace KonradMichalik\Typo3EnvironmentIndicator\Image\Modifier;
 use Imagick;
 use ImagickPixel;
 use Intervention\Image\Interfaces\ImageInterface;
-use KonradMichalik\Typo3EnvironmentIndicator\Utility\{ColorUtility, ImageDriverUtility};
+use KonradMichalik\Color\Color;
+use KonradMichalik\Typo3EnvironmentIndicator\Utility\ImageDriverUtility;
 use RuntimeException;
 
 use function array_key_exists;
@@ -38,9 +39,8 @@ class ColorizeModifier extends AbstractModifier implements ModifierInterface
             throw new RuntimeException('This modifier requires the Imagick driver', 1741785764);
         }
 
-        $targetColorArray = ColorUtility::colorToRgb($this->configuration['color']);
+        $targetColor = (Color::tryFromString($this->configuration['color']) ?? Color::fromRgb(0, 0, 0))->toRgb()->toCssString();
         $opacityPercentage = (($this->configuration['opacity'] ?? 1) * 100).'%';
-        $targetColor = sprintf('rgb(%d, %d, %d)', $targetColorArray[0], $targetColorArray[1], $targetColorArray[2]);
 
         $imagick = $image->core()->native();
         assert($imagick instanceof Imagick);

--- a/Classes/Utility/ColorUtility.php
+++ b/Classes/Utility/ColorUtility.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 
 namespace KonradMichalik\Typo3EnvironmentIndicator\Utility;
 
-use function is_string;
-use function sprintf;
-use function strlen;
+use KonradMichalik\Color\Color;
 
 /**
  * ColorUtility.
@@ -25,94 +23,10 @@ use function strlen;
  */
 class ColorUtility
 {
-    public static function getColoredString(?string $name = null): string
+    public static function getOptimalTextColor(string $color, float $opacity = 1, string $fallbackColor = '#000000'): string
     {
-        $name ??= (string) $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename'];
-        $hash = hash('sha256', $name);
-        $hue = hexdec(substr($hash, 0, 2)) / 255 * 360;
+        $background = Color::tryFromString($color) ?? Color::fromString($fallbackColor);
 
-        return sprintf('hsl(%d, 70%%, 60%%)', $hue);
-    }
-
-    /**
-     * @param array<int, int>|string $fallbackColor
-     */
-    public static function getOptimalTextColor(string $color, float $opacity = 1, array|string $fallbackColor = [0, 0, 0]): string
-    {
-        $rgb = self::colorToRgb($color, $fallbackColor);
-
-        return self::calculateLuminance($rgb[0], $rgb[1], $rgb[2]) > 0.5 ? "rgba(0,0,0,$opacity)" : "rgba(255,255,255,$opacity)";
-    }
-
-    /**
-     * @param array<int, int>|string $fallbackColor
-     *
-     * @return array<int, int>
-     */
-    public static function colorToRgb(string $color, array|string $fallbackColor = [0, 0, 0]): array
-    {
-        if (1 === preg_match('/^#([a-fA-F0-9]{3,6})$/', $color, $matches)) {
-            return self::hexToRgb($color);
-        }
-        if (1 === preg_match('/rgb\((\d+),\s*(\d+),\s*(\d+)\)/', $color, $matches)) {
-            return [(int) $matches[1], (int) $matches[2], (int) $matches[3]];
-        }
-        if (1 === preg_match('/hsl\((\d+),\s*(\d+)%?,\s*(\d+)%?\)/', $color, $matches)) {
-            $hslResult = self::hslToRgb((int) $matches[1], (int) $matches[2], (int) $matches[3]);
-
-            return [(int) $hslResult[0], (int) $hslResult[1], (int) $hslResult[2]];
-        }
-
-        if (is_string($fallbackColor)) {
-            $fallbackColor = self::colorToRgb($fallbackColor);
-        }
-
-        return $fallbackColor;
-    }
-
-    /**
-     * @return array<int, int>
-     */
-    public static function hexToRgb(string $hex): array
-    {
-        $hex = ltrim($hex, '#');
-        if (3 === strlen($hex)) {
-            $hex = "{$hex[0]}{$hex[0]}{$hex[1]}{$hex[1]}{$hex[2]}{$hex[2]}";
-        }
-
-        return [(int) hexdec($hex[0].$hex[1]), (int) hexdec($hex[2].$hex[3]), (int) hexdec($hex[4].$hex[5])];
-    }
-
-    /**
-     * @return array<int, float|int>
-     */
-    public static function hslToRgb(int $h, int $s, int $l): array
-    {
-        $s /= 100;
-        $l /= 100;
-        $c = (1 - abs(2 * $l - 1)) * $s;
-        $x = $c * (1 - abs(fmod($h / 60.0, 2) - 1));
-        $m = $l - $c / 2;
-
-        if ($h < 60) {
-            [$r, $g, $b] = [$c, $x, 0];
-        } elseif ($h < 120) {
-            [$r, $g, $b] = [$x, $c, 0];
-        } elseif ($h < 180) {
-            [$r, $g, $b] = [0, $c, $x];
-        } elseif ($h < 240) {
-            [$r, $g, $b] = [0, $x, $c];
-        } elseif ($h < 300) {
-            [$r, $g, $b] = [$x, 0, $c];
-        } else {
-            [$r, $g, $b] = [$c, 0, $x];
-        }
-
-        return [round(($r + $m) * 255), round(($g + $m) * 255), round(($b + $m) * 255)];
-    }
-
-    public static function calculateLuminance(int $r, int $g, int $b): float
-    {
-        return 0.2126 * ($r / 255) + 0.7152 * ($g / 255) + 0.0722 * ($b / 255);
+        return $background->optimalTextColor()->toRgbaString($opacity);
     }
 }

--- a/Tests/Unit/Utility/ColorUtilityTest.php
+++ b/Tests/Unit/Utility/ColorUtilityTest.php
@@ -24,108 +24,28 @@ use PHPUnit\Framework\TestCase;
  */
 class ColorUtilityTest extends TestCase
 {
-    public function testGetColoredStringWithName(): void
-    {
-        $result = ColorUtility::getColoredString('test');
-        self::assertStringStartsWith('hsl(', $result);
-        self::assertStringEndsWith(')', $result);
-    }
-
-    public function testGetColoredStringWithoutName(): void
-    {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename'] = 'Test Site';
-        $result = ColorUtility::getColoredString();
-        self::assertStringStartsWith('hsl(', $result);
-        self::assertStringEndsWith(')', $result);
-    }
-
     public function testGetOptimalTextColorForLightColor(): void
     {
-        $result = ColorUtility::getOptimalTextColor('#ffffff');
-        self::assertStringStartsWith('rgba(0,0,0,', $result);
+        self::assertSame('rgba(0, 0, 0, 1)', ColorUtility::getOptimalTextColor('#ffffff'));
     }
 
     public function testGetOptimalTextColorForDarkColor(): void
     {
-        $result = ColorUtility::getOptimalTextColor('#000000');
-        self::assertStringStartsWith('rgba(255,255,255,', $result);
+        self::assertSame('rgba(255, 255, 255, 1)', ColorUtility::getOptimalTextColor('#000000'));
     }
 
     public function testGetOptimalTextColorWithOpacity(): void
     {
-        $result = ColorUtility::getOptimalTextColor('#ffffff', 0.5);
-        self::assertStringContainsString('0.5', $result);
+        self::assertSame('rgba(0, 0, 0, 0.5)', ColorUtility::getOptimalTextColor('#ffffff', 0.5));
     }
 
-    public function testColorToRgbWithHex(): void
+    public function testGetOptimalTextColorFallsBackForUnparseableColor(): void
     {
-        $result = ColorUtility::colorToRgb('#ff0000');
-        self::assertEquals([255, 0, 0], $result);
+        self::assertSame('rgba(255, 255, 255, 1)', ColorUtility::getOptimalTextColor('transparent'));
     }
 
-    public function testColorToRgbWithShortHex(): void
+    public function testGetOptimalTextColorUsesCustomFallbackColor(): void
     {
-        $result = ColorUtility::colorToRgb('#f00');
-        self::assertEquals([255, 0, 0], $result);
-    }
-
-    public function testColorToRgbWithRgb(): void
-    {
-        $result = ColorUtility::colorToRgb('rgb(255, 0, 0)');
-        self::assertEquals([255, 0, 0], $result);
-    }
-
-    public function testColorToRgbWithHsl(): void
-    {
-        $result = ColorUtility::colorToRgb('hsl(0, 100%, 50%)');
-        self::assertEquals([255, 0, 0], $result);
-    }
-
-    public function testColorToRgbWithInvalidColor(): void
-    {
-        $result = ColorUtility::colorToRgb('invalid');
-        self::assertEquals([0, 0, 0], $result);
-    }
-
-    public function testColorToRgbWithStringFallback(): void
-    {
-        $result = ColorUtility::colorToRgb('invalid', '#ff0000');
-        self::assertEquals([255, 0, 0], $result);
-    }
-
-    public function testHexToRgb(): void
-    {
-        $result = ColorUtility::hexToRgb('#ff0000');
-        self::assertEquals([255, 0, 0], $result);
-    }
-
-    public function testHexToRgbWithShortHex(): void
-    {
-        $result = ColorUtility::hexToRgb('#f00');
-        self::assertEquals([255, 0, 0], $result);
-    }
-
-    public function testHslToRgb(): void
-    {
-        $result = ColorUtility::hslToRgb(0, 100, 50);
-        self::assertEquals([255, 0, 0], $result);
-    }
-
-    public function testHslToRgbWithBlue(): void
-    {
-        $result = ColorUtility::hslToRgb(240, 100, 50);
-        self::assertEquals([0, 0, 255], $result);
-    }
-
-    public function testCalculateLuminance(): void
-    {
-        $result = ColorUtility::calculateLuminance(255, 255, 255);
-        self::assertEquals(1.0, $result);
-    }
-
-    public function testCalculateLuminanceBlack(): void
-    {
-        $result = ColorUtility::calculateLuminance(0, 0, 0);
-        self::assertEquals(0.0, $result);
+        self::assertSame('rgba(0, 0, 0, 1)', ColorUtility::getOptimalTextColor('transparent', fallbackColor: '#ffffff'));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
 		"php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
 		"ext-filter": "*",
 		"intervention/image": "^3.11.7 || ^4.0",
+		"konradmichalik/php-color": "^0.2",
 		"konradmichalik/php-ico-file-loader": "^0.2",
 		"meyfa/php-svg": "^0.16",
 		"psr/http-message": "^1.0 || ^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15ab8a15956b82e743aeceececb8c4f7",
+    "content-hash": "1fa2ad54a7a1c5998c52f27a892ca361",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -1198,6 +1198,66 @@
                 }
             ],
             "time": "2026-05-01T08:20:10+00:00"
+        },
+        {
+            "name": "konradmichalik/php-color",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/konradmichalik/php-color.git",
+                "reference": "ce53155e764e7c7e82cf79da8d685f56f3553139"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/konradmichalik/php-color/zipball/ce53155e764e7c7e82cf79da8d685f56f3553139",
+                "reference": "ce53155e764e7c7e82cf79da8d685f56f3553139",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "armin/editorconfig-cli": "^2.0",
+                "ergebnis/composer-normalize": "^2.42",
+                "konradmichalik/php-cs-fixer-preset": "^0.2.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^11.0 || ^12.0",
+                "rector/rector": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "KonradMichalik\\Color\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Konrad Michalik",
+                    "email": "hej@konradmichalik.dev",
+                    "homepage": "https://konradmichalik.dev",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "A small, framework-agnostic PHP library for color conversion, luminance, contrast and deterministic string-to-color hashing.",
+            "keywords": [
+                "color",
+                "contrast",
+                "hex",
+                "hsl",
+                "luminance",
+                "rgb",
+                "wcag"
+            ],
+            "support": {
+                "issues": "https://github.com/konradmichalik/php-color/issues",
+                "source": "https://github.com/konradmichalik/php-color/tree/0.2.0"
+            },
+            "time": "2026-06-19T11:30:22+00:00"
         },
         {
             "name": "konradmichalik/php-ico-file-loader",


### PR DESCRIPTION
## Summary

- Replace the hand-rolled color math in `ColorUtility` with the dedicated [`konradmichalik/php-color`](https://github.com/konradmichalik/php-color) package
- Reduce `ColorUtility` to a single extension-specific adapter method (`getOptimalTextColor`), preserving opacity and fallback-background semantics
- Remove dead code (`getColoredString`) and now-redundant conversion helpers (`colorToRgb`, `hexToRgb`, `hslToRgb`, `calculateLuminance`)
- Net reduction of ~105 lines

## Changes

- `composer.json` - Add `konradmichalik/php-color: ^0.2` dependency
- `Classes/Utility/ColorUtility.php` - Slim from 118 to 31 lines; `getOptimalTextColor()` now delegates to `Color::tryFromString()` + `optimalTextColor()` + `toRgbaString()`
- `Classes/Image/Modifier/ColorizeModifier.php` - Replace `colorToRgb()` + manual `sprintf` with `Color::tryFromString(...)->toRgb()->toCssString()`
- `Tests/Unit/Utility/ColorUtilityTest.php` - Drop tests for removed methods; cover the adapter's opacity and fallback behavior

## Notes

- Text-color contrast now uses WCAG contrast ratio (`optimalTextColor()`) instead of a `luminance > 0.5` threshold — identical for black/white decisions, more correct at edge colors.
- The four call sites (`TopbarItem`, `ContextItem`, `EnvironmentIndicatorWidget`, `ContextUtility`) are unchanged.
- The `rgba()` output is now spaced (`rgba(0, 0, 0, 1)`), which is purely cosmetic in the templates.

## Test plan

- [x] `ddev composer test` — 301 tests pass
- [x] `ddev cgl sca` (PHPStan) — no errors
- [x] `ddev cgl lint:php` / `lint:composer` — clean